### PR TITLE
ci(docs): fix Deploy Docs failure (npm install for docs-site)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -44,8 +44,11 @@ jobs:
       - name: Build library
         run: npm run build
 
+      # `npm install` (not `npm ci`): the docs-site lockfile has no enforcing CI
+      # of its own and drifts from package.json (e.g. a dep added but lock not
+      # regenerated). install tolerates that; ci would hard-fail on any mismatch.
       - name: Install docs-site deps
-        run: npm ci
+        run: npm install --no-audit --no-fund --no-progress
         working-directory: docs-site
 
       - name: Build docs site


### PR DESCRIPTION
## 问题

合并 #2 后,`Deploy Docs` workflow 首次运行在 **Install docs-site deps** 步骤失败:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json are in sync.
npm error Missing: qrcode.react@4.2.0 from lock file
```

`docs-site/package-lock.json` 与 `package.json` 不同步(`qrcode.react` 加进了 deps 但没重新生成 lock),而 `npm ci` 要求严格一致,一漂移就硬失败。前面的 checkout / 装根依赖 / 构建库都正常。

## 修复

把 docs-site 那步从 `npm ci` 换成 `npm install --no-audit --no-fund --no-progress`。docs-site 的 lockfile 没有独立 CI 守护、容易漂移,`npm install` 会按需更新而不是硬失败。根依赖仍用 `npm ci`(其 lock 有根 CI 守护、保持同步)。

合入后 `Deploy Docs` 会重新触发并把最新文档站发布到 gh-pages。

🤖 Generated with [Claude Code](https://claude.com/claude-code)