### PR TITLE
docs(changelog): 1.0.2 — Alipay CDN fonts, streaming flicker/marker fixes, Minifish exports

### DIFF
--- a/changelog/CHANGELOG.en-US.md
+++ b/changelog/CHANGELOG.en-US.md
@@ -8,6 +8,16 @@ User-facing API, build-output, and behavior changes are tracked here. Migration 
 
 > The site's `/changelog` timeline is generated from this file (`docs-site/scripts/build-changelog.mjs` parses the `## version` / `` `date` `` / `- **type**: …` structure). Add a new block at the top when releasing; `npm run changelog` helps assemble entries from merged PRs. Types are **Breaking** / **Added** / **Fixed** / **Improved**.
 
+## 1.0.2
+
+`2026-07-07`
+
+- **Fixed**: KaTeX formulas fell back to the system font on the Alipay real device. On device `my.loadFontFace` only accepts an https network font whose domain is on the download allowlist; package-local ttf paths and base64 data URIs work only in the simulator (they appeared to work in this repo's own examples only because the examples sync the fonts to the project root). KaTeX fonts now load from a whitelisted CDN (`mdn.alipayobjects.com`, 20 ttf). **Consumers must add the font CDN domain to their mini-program download allowlist.** WeChat keeps its resolvable local `miniprogram_npm` ttf (first) + shared CDN (fallback).
+- **Fixed**: whole-page flicker while streaming formulas. `MiniNodeRenderer` re-registered a font-ready callback on every chunk, and the callback fired synchronously once fonts were cached, unmounting/remounting the entire render tree each chunk. Each component instance now reflows at most once, and only when there is a formula, fonts aren't ready yet, and streaming is not in progress.
+- **Fixed**: ordered-list markers (e.g. `1.`) wrapped across lines while streaming. The per-character entrance animation split the marker into separate `<text>` boxes, so `1` and `.` broke onto different lines inside the 28rpx-wide marker column. Markers now render as a single `<text>`, matching WeChat.
+- **Fixed**: bundlers that honor `package.json#exports` (e.g. Minifish 2.0) couldn't resolve and failed to load the `<markdown>` component. Added `./es/Markdown/index` and `./es/MiniNodeRenderer/index` no-extension subpath export maps (Node's `*` glob does not auto-append extensions).
+- **Improved**: removed the inlined base64 font data module (`katex-font-data.js`) and the Alipay-root ttf; the font loader is now shipped once per package root (`shared/loadKatexFonts.js`) instead of inlined into every component wrapper. Smaller package.
+
 ## 1.0.1
 
 `2026-07-05`

--- a/changelog/CHANGELOG.zh-CN.md
+++ b/changelog/CHANGELOG.zh-CN.md
@@ -8,6 +8,16 @@ title: 更新日志
 
 > 官网 `/changelog` 时间轴由本文件生成（`docs-site/scripts/build-changelog.mjs` 解析 `## 版本`／`` `日期` ``／`- **类型**：…` 结构）。发版时在顶部新增一段即可，`npm run changelog` 可辅助从已合并 PR 拼条目。类型取 **破坏性** / **新增** / **修复** / **优化**。
 
+## 1.0.2
+
+`2026-07-07`
+
+- **修复**：支付宝真机上 KaTeX 公式回退成系统字体。真机 `my.loadFontFace` 只认「已加入下载合法域名白名单的 https 网络字体」，包内本地 ttf 路径与 base64 data URI 仅在模拟器生效（此前它们能在本仓库自带 examples 里工作，是因为 examples 把字体同步到了工程根目录）。现改为从白名单 CDN 加载 KaTeX 字体（`mdn.alipayobjects.com`，20 个 ttf）。**使用方需将该字体 CDN 域名加入小程序「下载合法域名」白名单。** 微信仍保留可解析的本地 `miniprogram_npm` ttf（优先）+ 共享 CDN（兜底）。
+- **修复**：流式渲染公式时整页反复闪动。此前 `MiniNodeRenderer` 每收到一个 chunk 都会重新注册字体就绪回调，字体缓存后回调又同步触发，导致整棵渲染树反复「卸载-重挂」。现每个组件实例至多重排一次，且仅在「有公式 + 字体尚未就绪 + 非流式进行中」时触发。
+- **修复**：流式时有序列表序号（如 `1.`）换行。逐字入场动画把 marker 拆成多个 `<text>`，在仅 28rpx 宽的 marker 列里 `1` 和 `.` 分行。marker 现整体渲染为单个 `<text>`，与微信一致。
+- **修复**：尊重 `package.json#exports` 的构建工具（如 Minifish 2.0）无法解析、加载不出 `<markdown>` 组件。新增 `./es/Markdown/index` 与 `./es/MiniNodeRenderer/index` 无扩展名子路径导出映射（Node 的 `*` 通配不会自动补扩展名）。
+- **优化**：移除内联 base64 字体数据模块（`katex-font-data.js`）与支付宝包根 ttf；字体 loader 抽为每个包根仅发一份的 `shared/loadKatexFonts.js`（不再内联进每个组件 wrapper）。包体减小。
+
 ## 1.0.1
 
 `2026-07-05`

--- a/docs-site/public/site.js
+++ b/docs-site/public/site.js
@@ -893,7 +893,7 @@
   // a version label to the URL serving that version's docs. The current build
   // is always the default; entries listed here become extra dropdown options.
   var GITHUB_URL = 'https://github.com/ant-design/x-markdown-mini';
-  var CURRENT_VERSION = '1.0.1';
+  var CURRENT_VERSION = '1.0.2';
   var VERSION_MIRRORS = {
     // '1.x': 'https://1x-x-markdown-mini.example.com',
   };

--- a/examples/alipay/package.json
+++ b/examples/alipay/package.json
@@ -3,7 +3,7 @@
     "postinstall": "node ./scripts/patch-mp-html.mjs"
   },
   "dependencies": {
-    "@ant-design/x-markdown-mini": "1.0.1",
+    "@ant-design/x-markdown-mini": "1.0.2",
     "mini-html-parser2": "^0.3.0",
     "mp-html": "^2.5.2",
     "towxml": "^3.0.6"

--- a/examples/wechat/package.json
+++ b/examples/wechat/package.json
@@ -7,7 +7,7 @@
     "postinstall": "node ./scripts/sync-npm-fixtures.mjs"
   },
   "dependencies": {
-    "@ant-design/x-markdown-mini": "1.0.1",
+    "@ant-design/x-markdown-mini": "1.0.2",
     "mini-html-parser2": "^0.3.0",
     "mp-html": "^2.5.2",
     "towxml": "^3.0.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/x-markdown-mini",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "多小程序场景下的高性能、强扩展、流式友好的 Markdown 渲染器",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Release notes for **1.0.2**, covering #12 (library fix) and #13 (WeChat example fixture). **Merge after #12 and #13**, then `npm run release`.

### 💡 Background and Solution

Adds the `## 1.0.2` block to `changelog/CHANGELOG.zh-CN.md` + `changelog/CHANGELOG.en-US.md` (the source the docs-site `/changelog` timeline is generated from) and bumps the version in the four test-gated spots: `package.json`, `docs-site/public/site.js` (`CURRENT_VERSION`), `examples/alipay/package.json`, `examples/wechat/package.json`.

1.0.2 is a patch: all changes are fixes plus a bundle-size improvement; no breaking changes, no new public runtime API.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Alipay real-device KaTeX now loads fonts from a whitelisted CDN (**add the font CDN domain to your mini-program download allowlist**); fixed whole-page flicker and split list markers while streaming; added `./es/Markdown/index` and `./es/MiniNodeRenderer/index` export subpaths for bundlers honoring `package.json#exports` (e.g. Minifish); smaller package (removed inlined base64 fonts). |
| 🇨🇳 Chinese | 支付宝真机 KaTeX 改为从白名单 CDN 加载字体（**需在小程序「下载合法域名」中加入字体 CDN 域名**）；修复流式渲染公式时整页闪动与列表序号换行；新增 `./es/Markdown/index` 与 `./es/MiniNodeRenderer/index` 导出子路径以适配尊重 `package.json#exports` 的构建工具（如 Minifish）；包体减小（移除内联 base64 字体）。 |
