### PR TITLE
feat: render <details> blocks as collapsible sections

### DIFF
--- a/scripts/check-bundle.mjs
+++ b/scripts/check-bundle.mjs
@@ -63,10 +63,13 @@ const BUDGETS = [
   // raw +~0.3 KB：src/polyfills.ts 的 Array/String#at 守卫（修复 iOS<15.4 / 旧
   //   基础库 marked `.at(-1)` 抛 "x.at is not a function" 整包白屏；es-check 只查
   //   语法查不到运行时方法）。实测 mjs raw ~122.27 KB、index.js ~123.79 KB。
-  { file: 'index.mjs', rawMax: 123 * KB, gzipMax: 30 * KB },
-  { file: 'index.js', rawMax: 125 * KB, gzipMax: 31 * KB },
+  // raw +~1.3 KB / gzip +~0.4 KB: built-in <details> block tokenizer +
+  //   'details' MiniNode mapping + per-call extension snapshot deep-clone.
+  //   Measured mjs raw ~124.29 KB / gzip ~30.40 KB, index.js ~125.81 KB.
+  { file: 'index.mjs', rawMax: 126 * KB, gzipMax: 31 * KB },
+  { file: 'index.js', rawMax: 128 * KB, gzipMax: 32 * KB },
   // 微信专用主库副本（通过 package.json#miniprogram 进入）
-  { file: 'miniprogram_dist/index.js', rawMax: 125 * KB, gzipMax: 31 * KB },
+  { file: 'miniprogram_dist/index.js', rawMax: 128 * KB, gzipMax: 32 * KB },
   // 共享 helper（alipay 包根 + wechat 包根 各一份）。JS 接入复用时间戳
   // 动画协调器完整内联后约 7.59 KB，只让新增字符渐显，避免微信旧字符重复播放；
   // 入口必须自包含，不能留下未发布的 ./textAnimation.js require。

--- a/src/XMarkdownMini.ts
+++ b/src/XMarkdownMini.ts
@@ -278,6 +278,18 @@ export class XMarkdownMini {
         childTokens: { ...ext.childTokens },
       };
     }
+    // use() likewise mutates existing defaults.renderer / defaults.tokenizer
+    // class instances in place (override slots are written onto the instance).
+    // Clone them preserving the prototype — a plain object spread would drop
+    // the prototype methods and break rendering after restore.
+    const cloneInstance = <T extends object>(o: T): T =>
+      Object.assign(Object.create(Object.getPrototypeOf(o)), o);
+    if (this.marked.defaults.renderer) {
+      saved.renderer = cloneInstance(this.marked.defaults.renderer);
+    }
+    if (this.marked.defaults.tokenizer) {
+      saved.tokenizer = cloneInstance(this.marked.defaults.tokenizer);
+    }
     this.marked.use(...(perCall as MarkedExtension[]));
     return saved;
   }

--- a/src/XMarkdownMini.ts
+++ b/src/XMarkdownMini.ts
@@ -1,4 +1,5 @@
 import { Marked, type MarkedExtension, type MarkedOptions, type Token, type Tokens } from 'marked';
+import { detailsExtension } from './extensions/details.js';
 import { getPlatformRenderer, resolvePlatform } from './platforms/index.js';
 import { StreamingProcessor } from './streaming/StreamingProcessor.js';
 import {
@@ -208,7 +209,11 @@ export class XMarkdownMini {
       opts.components && opts.components.length > 0
         ? synthesizeComponentsExtension(opts.components)
         : undefined;
+    // Built-in <details> block tokenizer registered FIRST: marked unshifts
+    // block tokenizers per use() call, so later (user) registrations still
+    // run before it and can take over the token.
     const allMarkedExtensions: MarkedExtension[] = [
+      detailsExtension as MarkedExtension,
       ...(directExtensions as MarkedExtension[]),
       ...(this.componentsExtension ? [this.componentsExtension as MarkedExtension] : []),
     ];
@@ -256,6 +261,23 @@ export class XMarkdownMini {
   ): MarkedOptions | null {
     if (!perCall || perCall.length === 0) return null;
     const saved = { ...this.marked.defaults };
+    // marked's use() mutates an existing defaults.extensions container in
+    // place (tokenizers are unshifted into its arrays). Since the built-in
+    // details extension guarantees the container exists, a shallow defaults
+    // spread would alias the mutated container and restore nothing — clone
+    // its arrays/maps into the snapshot so restoreDefaults really reverts.
+    const ext = this.marked.defaults.extensions;
+    if (ext) {
+      saved.extensions = {
+        ...ext,
+        ...(ext.block ? { block: [...ext.block] } : {}),
+        ...(ext.inline ? { inline: [...ext.inline] } : {}),
+        ...(ext.startBlock ? { startBlock: [...ext.startBlock] } : {}),
+        ...(ext.startInline ? { startInline: [...ext.startInline] } : {}),
+        renderers: { ...ext.renderers },
+        childTokens: { ...ext.childTokens },
+      };
+    }
     this.marked.use(...(perCall as MarkedExtension[]));
     return saved;
   }

--- a/src/__tests__/details.test.ts
+++ b/src/__tests__/details.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { XMarkdownMini } from '../XMarkdownMini.js';
+import type { MiniNode } from '../types.js';
+
+function renderWechat(content: string): MiniNode[] {
+  return new XMarkdownMini({ escapeText: false }).renderNodes({
+    content,
+    platform: 'wechat',
+  });
+}
+
+function flatten(nodes: MiniNode[]): MiniNode[] {
+  const out: MiniNode[] = [];
+  const queue = [...nodes];
+  while (queue.length) {
+    const n = queue.shift()!;
+    out.push(n);
+    if (n.children) queue.push(...n.children);
+  }
+  return out;
+}
+
+describe('<details> block support', () => {
+  it('renders an empty details block with its summary', () => {
+    const out = renderWechat('<details>\n  <summary>Preview</summary>\n</details>');
+    expect(out).toHaveLength(1);
+    const details = out[0];
+    expect(details.name).toBe('details');
+    expect(details.attrs?.class).toBe('md-details');
+    expect(details.attrs?.summary).toBe('Preview');
+    expect(details.attrs?.open).toBeUndefined();
+    expect(details.children ?? []).toHaveLength(0);
+  });
+
+  it('parses a markdown body that contains blank lines and lists', () => {
+    const out = renderWechat(
+      '<details>\n<summary>More</summary>\n\nSome **bold** text\n\n- item\n\n</details>\n\nafter',
+    );
+    expect(out[0].name).toBe('details');
+    const inner = flatten(out[0].children ?? []);
+    expect(inner.some((n) => n.name === 'strong')).toBe(true);
+    expect(inner.some((n) => n.name === 'ul')).toBe(true);
+    // No leaked raw html text inside or after the details block.
+    const values = flatten(out).map((n) => String(n.attrs?.value ?? ''));
+    expect(values.some((v) => v.includes('<details') || v.includes('</details'))).toBe(false);
+    expect(out[out.length - 1].name).toBe('p');
+  });
+
+  it('honors the open attribute', () => {
+    const out = renderWechat('<details open>\n<summary>S</summary>\n\nbody\n\n</details>');
+    expect(out[0].attrs?.open).toBe(true);
+  });
+
+  it('strips tags from the summary and tolerates a missing summary', () => {
+    const tagged = renderWechat('<details><summary><b>Bold</b> label</summary>\n\nx\n\n</details>');
+    expect(tagged[0].attrs?.summary).toBe('Bold label');
+
+    const none = renderWechat('<details>\n\njust a body\n\n</details>');
+    expect(none[0].name).toBe('details');
+    expect(none[0].attrs?.summary).toBe('');
+    expect(flatten(none[0].children ?? []).some((n) => n.name === 'p')).toBe(true);
+  });
+
+  it('leaves other raw html blocks untouched', () => {
+    const out = renderWechat('<section>\nplain\n</section>');
+    expect(out[0].name).toBe('div');
+    expect(out[0].children?.[0].attrs?.value).toContain('<section>');
+  });
+
+  it('lets a user extension named details take over rendering', () => {
+    const md = new XMarkdownMini({
+      escapeText: false,
+      extensions: [
+        {
+          extensions: [
+            {
+              name: 'details',
+              miniRenderer: () => ({ name: 'div', attrs: { class: 'custom-details' } }),
+            },
+          ],
+        },
+      ],
+    });
+    const out = md.renderNodes({
+      content: '<details><summary>S</summary></details>',
+      platform: 'wechat',
+    });
+    expect(out[0].attrs?.class).toBe('custom-details');
+  });
+});

--- a/src/__tests__/details.test.ts
+++ b/src/__tests__/details.test.ts
@@ -51,6 +51,14 @@ describe('<details> block support', () => {
     expect(out[0].attrs?.open).toBe(true);
   });
 
+  it('does not mistake "open" inside a quoted attribute value for the open attribute', () => {
+    const out = renderWechat(
+      '<details class="foo open">\n<summary>S</summary>\n\nbody\n\n</details>',
+    );
+    expect(out[0].name).toBe('details');
+    expect(out[0].attrs?.open).toBeUndefined();
+  });
+
   it('strips tags from the summary and tolerates a missing summary', () => {
     const tagged = renderWechat('<details><summary><b>Bold</b> label</summary>\n\nx\n\n</details>');
     expect(tagged[0].attrs?.summary).toBe('Bold label');

--- a/src/__tests__/extensions.test.ts
+++ b/src/__tests__/extensions.test.ts
@@ -103,6 +103,41 @@ describe('XMarkdownMini — extensions', () => {
     expect((afterPara.tokens ?? []).some((t) => t.type === 'mention')).toBe(false);
   });
 
+  it('per-call tokenizer overrides do not leak after completion', () => {
+    // Constructor-level tokenizer override forces defaults.tokenizer to exist,
+    // so the per-call use() mutates that instance in place — the case the
+    // snapshot in applyPerCallExtensions must deep-clone to restore.
+    const passthrough: MarkedExtension = { tokenizer: { br: () => false } };
+    const shoutCodespan: MarkedExtension = {
+      tokenizer: {
+        codespan(src: string) {
+          const m = /^`([^`]+)`/.exec(src);
+          if (!m) return false;
+          return { type: 'codespan', raw: m[0], text: m[1].toUpperCase() } as Tokens.Codespan;
+        },
+      },
+    };
+    const md = new XMarkdownMini({ extensions: [passthrough] });
+
+    let tokens: Token[] = [];
+    md.render({
+      content: 'see `code`',
+      streaming: { hasNextChunk: false },
+      extensions: [shoutCodespan],
+      onPatch: (next) => {
+        tokens = next;
+      },
+    });
+    const streamedPara = tokens.find((t) => t.type === 'paragraph') as Tokens.Paragraph;
+    const streamedCode = (streamedPara.tokens ?? []).find((t) => t.type === 'codespan') as Tokens.Codespan;
+    expect(streamedCode.text).toBe('CODE');
+
+    const after = md.parse('see `code`');
+    const afterPara = after.find((t) => t.type === 'paragraph') as Tokens.Paragraph;
+    const afterCode = (afterPara.tokens ?? []).find((t) => t.type === 'codespan') as Tokens.Codespan;
+    expect(afterCode.text).toBe('code');
+  });
+
   it('no extensions: legacy XMarkdownMini behavior preserved (mention is plain text)', () => {
     const md = new XMarkdownMini();
     const tokens = md.parse('hi @alice');

--- a/src/components/alipay/MiniNodeRenderer/index.axml
+++ b/src/components/alipay/MiniNodeRenderer/index.axml
@@ -175,7 +175,7 @@
 
   <!-- details: collapsible section. Summary row toggles per-index open state;
        default open comes from the <details open> attribute on the node. -->
-  <view a:elif="{{u.isDetails(node.name)}}" class="md-details">
+  <view a:elif="{{u.isDetails(node.name)}}" class="{{u.classOf(node)}}">
     <view
       class="md-details-summary"
       data-i="{{i}}"

--- a/src/components/alipay/MiniNodeRenderer/index.axml
+++ b/src/components/alipay/MiniNodeRenderer/index.axml
@@ -173,6 +173,33 @@
     </view>
   </view>
 
+  <!-- details: collapsible section. Summary row toggles per-index open state;
+       default open comes from the <details open> attribute on the node. -->
+  <view a:elif="{{u.isDetails(node.name)}}" class="md-details">
+    <view
+      class="md-details-summary"
+      data-i="{{i}}"
+      data-open="{{u.detailsOpenState(detailsOpen, i, node)}}"
+      catchTap="_toggleDetails"
+    >
+      <text class="md-details-arrow {{u.detailsOpenState(detailsOpen, i, node) ? 'md-details-arrow--open' : ''}}">▶</text>
+      <text class="md-details-summary-text">{{u.summaryOf(node)}}</text>
+    </view>
+    <view a:if="{{u.detailsOpenState(detailsOpen, i, node)}}" class="md-details-body">
+      <mini-node-renderer
+        a:if="{{node.children}}"
+        nodes="{{node.children}}"
+        selectable="{{selectable}}"
+        animation="{{animation}}"
+        slotComponents="{{slotComponents}}"
+        onTap="onTap"
+        onAppear="onAppear"
+      >
+        <slot slot-scope="prop" data="{{prop.data}}" />
+      </mini-node-renderer>
+    </view>
+  </view>
+
   <!-- anchor：flatten 已把链接展开成「自带 value、无 children」的叶子 run（每段文本一个
        a 节点，br 单独成兄弟节点走上面的 isBr 分支）。这里直接渲染为单个可点击 <text>，
        与前后文本同级——外包 <view> 即使 display:inline 也会生成布局盒、打断行内排版。

--- a/src/components/alipay/MiniNodeRenderer/index.sjs
+++ b/src/components/alipay/MiniNodeRenderer/index.sjs
@@ -15,6 +15,14 @@ function isHr(name) { return name === 'hr'; }
 function isPre(name) { return name === 'pre'; }
 function isTable(name) { return name === 'table'; }
 function isCopy(name) { return name === 'copy-button'; }
+function isDetails(name) { return name === 'details'; }
+function summaryOf(node) { return (node.attrs || {}).summary || 'Details'; }
+// Open state: a user toggle in detailsOpen[i] wins; otherwise fall back to
+// the node's own `open` attribute (<details open>).
+function detailsOpenState(map, key, node) {
+  if (map && map[key] !== undefined) return !!map[key];
+  return !!((node.attrs || {}).open);
+}
 function copyOf(node) {
   var attrs = node.attrs || {};
   return attrs['data-copy'] || '';
@@ -136,6 +144,9 @@ export default {
   isPre: isPre,
   isTable: isTable,
   isCopy: isCopy,
+  isDetails: isDetails,
+  summaryOf: summaryOf,
+  detailsOpenState: detailsOpenState,
   copyOf: copyOf,
   isRich: isRich,
   isSlot: isSlot,

--- a/src/components/alipay/MiniNodeRenderer/index.ts
+++ b/src/components/alipay/MiniNodeRenderer/index.ts
@@ -53,6 +53,9 @@ Component({
   props: defaultProps,
   data: {
     shadows: {} as Record<string, EdgeShadowState>,
+    // Per-node-index override of <details> open state; unset = node's own
+    // `open` attr (see sjs detailsOpenState).
+    detailsOpen: {} as Record<string, boolean>,
     // 字体就绪后卸载-重挂一次，强制公式 <text> 用已注册字体重画（仅最外层实例会被回调，见 loadKatexFonts）。
     katexReflow: true,
   },
@@ -128,6 +131,12 @@ Component({
     _copy(this: any, e: any) {
       const ds = e && e.currentTarget && e.currentTarget.dataset;
       copyToClipboard((ds && ds.copy) || '');
+    },
+    _toggleDetails(this: any, e: any) {
+      const ds = (e && e.currentTarget && e.currentTarget.dataset) || {};
+      const detailsOpen = Object.assign({}, this.data.detailsOpen);
+      detailsOpen[ds.i] = !ds.open;
+      this.setData({ detailsOpen });
     },
     _scheduleMeasure(this: any) {
       if (this.timer !== null) clearTimeout(this.timer);

--- a/src/components/shared/elements.css
+++ b/src/components/shared/elements.css
@@ -142,6 +142,41 @@
   background: linear-gradient(270deg, rgba(51, 51, 51, 0.16), rgba(51, 51, 51, 0));
 }
 
+/* Collapsible <details> section */
+.md-details {
+  display: block;
+  margin: 16rpx 0;
+  border: 1px solid #e5e5e5;
+  border-radius: 12rpx;
+  overflow: hidden;
+}
+.md-details-summary {
+  display: flex;
+  align-items: center;
+  padding: 16rpx 20rpx;
+  background: #fafafa;
+}
+.md-details-arrow {
+  flex: none;
+  margin-right: 12rpx;
+  font-size: 20rpx;
+  color: #999;
+  transition: transform 0.2s ease;
+}
+.md-details-arrow--open {
+  transform: rotate(90deg);
+}
+.md-details-summary-text {
+  flex: 1;
+  min-width: 0;
+  font-weight: 600;
+}
+.md-details-body {
+  display: block;
+  padding: 16rpx 20rpx 4rpx;
+  border-top: 1px solid #e5e5e5;
+}
+
 /* 荧光标记 / 上下标 */
 .md-mark {
   border-radius: 4rpx;

--- a/src/components/shared/elements.css
+++ b/src/components/shared/elements.css
@@ -157,6 +157,9 @@
   background: #fafafa;
 }
 .md-details-arrow {
+  /* Explicit inline-block: some older engines ignore transforms on inline
+     <text> even when it is blockified as a flex item. */
+  display: inline-block;
   flex: none;
   margin-right: 12rpx;
   font-size: 20rpx;

--- a/src/components/wechat/MiniNodeRenderer/index.ts
+++ b/src/components/wechat/MiniNodeRenderer/index.ts
@@ -44,6 +44,9 @@ Component({
   },
   data: {
     tableShadows: {} as Record<string, { left: boolean; right: boolean }>,
+    // Per-node-index override of <details> open state; unset = node's own
+    // `open` attr (see wxs detailsOpenState).
+    detailsOpen: {} as Record<string, boolean>,
   },
   _tableViewportWidths: {} as Record<string, number>,
   _tableContentWidths: {} as Record<string, number>,
@@ -89,6 +92,10 @@ Component({
     _copy(this: any, e: any) {
       const ds = e && e.currentTarget && e.currentTarget.dataset;
       copyToClipboard((ds && ds.copy) || '');
+    },
+    _toggleDetails(this: any, e: any) {
+      const ds = (e && e.currentTarget && e.currentTarget.dataset) || {};
+      this.setData({ ['detailsOpen.' + ds.i]: !ds.open });
     },
     _scheduleTableMeasure(this: any) {
       if (this._tableMeasureTimer !== null) clearTimeout(this._tableMeasureTimer);

--- a/src/components/wechat/MiniNodeRenderer/index.wxml
+++ b/src/components/wechat/MiniNodeRenderer/index.wxml
@@ -190,6 +190,32 @@
     </view>
   </view>
 
+  <!-- details: collapsible section. Summary row toggles per-index open state;
+       default open comes from the <details open> attribute on the node. -->
+  <view wx:elif="{{u.isDetails(node.name)}}" class="md-details">
+    <view
+      class="md-details-summary"
+      data-i="{{i}}"
+      data-open="{{u.detailsOpenState(detailsOpen, i, node)}}"
+      catch:tap="_toggleDetails"
+    >
+      <text class="md-details-arrow {{u.detailsOpenState(detailsOpen, i, node) ? 'md-details-arrow--open' : ''}}">▶</text>
+      <text class="md-details-summary-text">{{u.summaryOf(node)}}</text>
+    </view>
+    <view wx:if="{{u.detailsOpenState(detailsOpen, i, node)}}" class="md-details-body">
+      <mini-node-renderer
+        wx:if="{{node.children}}"
+        generic:custom-slot="custom-slot"
+        nodes="{{node.children}}"
+        selectable="{{selectable}}"
+        animation="{{animation}}"
+        slotComponents="{{slotComponents}}"
+        bind:tap="_tap"
+        bind:appear="_appear"
+      />
+    </view>
+  </view>
+
   <!-- inline tag rendered as <text>: children are flat text runs -->
   <text
     wx:elif="{{u.isInline(node.name) && !u.isRich(node)}}"

--- a/src/components/wechat/MiniNodeRenderer/index.wxml
+++ b/src/components/wechat/MiniNodeRenderer/index.wxml
@@ -192,7 +192,7 @@
 
   <!-- details: collapsible section. Summary row toggles per-index open state;
        default open comes from the <details open> attribute on the node. -->
-  <view wx:elif="{{u.isDetails(node.name)}}" class="md-details">
+  <view wx:elif="{{u.isDetails(node.name)}}" class="{{u.classOf(node)}}">
     <view
       class="md-details-summary"
       data-i="{{i}}"

--- a/src/components/wechat/MiniNodeRenderer/index.wxs
+++ b/src/components/wechat/MiniNodeRenderer/index.wxs
@@ -8,6 +8,14 @@ function isHr(name) { return name === 'hr'; }
 function isPre(name) { return name === 'pre'; }
 function isTable(name) { return name === 'table'; }
 function isCopy(name) { return name === 'copy-button'; }
+function isDetails(name) { return name === 'details'; }
+function summaryOf(node) { return (node.attrs || {}).summary || 'Details'; }
+// Open state: a user toggle in detailsOpen[i] wins; otherwise fall back to
+// the node's own `open` attribute (<details open>).
+function detailsOpenState(map, key, node) {
+  if (map && map[key] !== undefined) return !!map[key];
+  return !!((node.attrs || {}).open);
+}
 function isKatex(node) {
   var cls = (node.attrs || {})['class'] || '';
   return cls.indexOf('katex') > -1;
@@ -100,6 +108,9 @@ module.exports = {
   isPre: isPre,
   isTable: isTable,
   isCopy: isCopy,
+  isDetails: isDetails,
+  summaryOf: summaryOf,
+  detailsOpenState: detailsOpenState,
   isKatex: isKatex,
   isListItem: isListItem,
   leftShadowClass: leftShadowClass,

--- a/src/extensions/details.ts
+++ b/src/extensions/details.ts
@@ -47,11 +47,14 @@ export const detailsExtension: XMarkdownExtension = {
         const body = (m[3] ?? '').trim();
         const tokens: Token[] = [];
         if (body) this.lexer.blockTokens(body, tokens);
+        // Strip quoted attribute values before probing for `open`, so e.g.
+        // <details class="foo open"> does not count as an open attribute.
+        const attrs = (m[1] ?? '').replace(/"[^"]*"|'[^']*'/g, '');
         return {
           type: 'details',
           raw: m[0],
           summary,
-          open: /(?:^|\s)open(?:\s|=|$)/i.test(m[1] ?? ''),
+          open: /(?:^|\s)open(?:\s|=|$)/i.test(attrs),
           tokens,
         };
       },

--- a/src/extensions/details.ts
+++ b/src/extensions/details.ts
@@ -1,0 +1,60 @@
+import type { Token, Tokens } from 'marked';
+import type { XMarkdownExtension } from '../types.js';
+
+/**
+ * Built-in `<details>` support.
+ *
+ * marked's html tokenizer splits a `<details>` block at the first blank line,
+ * so `<details>` with a markdown body arrives as several unrelated tokens and
+ * used to render as raw text. This block tokenizer runs before the built-in
+ * html tokenizer and captures the whole `<details>…</details>` region in one
+ * `details` token:
+ *
+ * - `summary`: plain text of the leading `<summary>…</summary>` (tags stripped)
+ * - `open`: whether the opening tag carries the `open` attribute
+ * - `tokens`: the body lexed as block markdown
+ *
+ * The shared miniNodeRenderer maps it to a `details` MiniNode that the bundled
+ * MiniNodeRenderer components render as a collapsible section.
+ *
+ * Limitation: the body match is non-greedy to the first `</details>`, so
+ * same-tag nesting does not nest (mirrors the `components` sugar limitation).
+ */
+export interface DetailsToken extends Tokens.Generic {
+  type: 'details';
+  raw: string;
+  summary: string;
+  open: boolean;
+  tokens: Token[];
+}
+
+const DETAILS_RE =
+  /^ {0,3}<details((?:\s+[^>]*?)?)>\s*(?:<summary(?:\s+[^>]*?)?>([\s\S]*?)<\/summary>)?([\s\S]*?)<\/details>[ \t]*(?:\n+|$)/i;
+
+export const detailsExtension: XMarkdownExtension = {
+  extensions: [
+    {
+      name: 'details',
+      level: 'block',
+      start(src: string) {
+        const i = src.toLowerCase().indexOf('<details');
+        return i < 0 ? undefined : i;
+      },
+      tokenizer(this: any, src: string): DetailsToken | undefined {
+        const m = DETAILS_RE.exec(src);
+        if (!m) return undefined;
+        const summary = (m[2] ?? '').replace(/<[^>]+>/g, '').trim();
+        const body = (m[3] ?? '').trim();
+        const tokens: Token[] = [];
+        if (body) this.lexer.blockTokens(body, tokens);
+        return {
+          type: 'details',
+          raw: m[0],
+          summary,
+          open: /(?:^|\s)open(?:\s|=|$)/i.test(m[1] ?? ''),
+          tokens,
+        };
+      },
+    },
+  ],
+};

--- a/src/platforms/shared/miniNodeRenderer.ts
+++ b/src/platforms/shared/miniNodeRenderer.ts
@@ -224,6 +224,19 @@ function blockTok(
       const raw = (t.text ?? t.raw ?? '').replace(/\s+$/, '');
       return block('div', raw ? [{ name: 'text', attrs: { value: raw } }] : [], animate, adapter, tok);
     }
+    case 'details': {
+      // Emitted by the built-in <details> block tokenizer (extensions/details.ts).
+      // An extension named 'details' with a miniRenderer/renderer overrides it.
+      const t = tok as unknown as { summary?: string; open?: boolean; tokens?: Token[] };
+      const custom = renderCustomToken(tok, ctx);
+      if (custom.length) {
+        return custom.length === 1 ? custom[0] : block('div', custom, animate, adapter, tok);
+      }
+      const children = blockTokens(t.tokens ?? [], adapter, animate, enc, ctx);
+      const attrs: MiniNodeAttrs = { class: 'md-details', summary: enc(t.summary ?? '') };
+      if (t.open) attrs.open = true;
+      return block('details', children, animate, adapter, tok, attrs);
+    }
     case 'table': {
       const t = tok as Tokens.Table;
       // Extension override: an extension whose miniRenderer/renderer is named


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #15

### 💡 Background and Solution

`<details>` blocks in markdown source rendered as raw text: block `html` tokens are emitted as a raw-text `div`, and when the body contains blank lines marked's html tokenizer additionally splits the region into several unrelated tokens, leaking `<details>` / `</details>` around otherwise-rendered content. See #15 for details.

Solution:

- **Built-in block tokenizer** (`src/extensions/details.ts`), registered on every `XMarkdownMini` instance. It runs before marked's html tokenizer and captures the whole `<details>…</details>` region in one `details` token: plain-text summary (tags stripped), `open` flag from the opening tag, and the body lexed as regular block markdown via `this.lexer.blockTokens`. It is registered first so user extensions (unshifted later by marked) still take precedence, and the shared renderer resolves a user extension named `details` through `renderCustomToken` before the built-in mapping — so existing custom handling keeps working.
- **Shared renderer mapping** (`miniNodeRenderer.ts`): `details` tokens become `{ name: 'details', attrs: { class: 'md-details', summary, open? }, children }` for all platforms.
- **Component UI**: the WeChat and Alipay `MiniNodeRenderer` components render a collapsible section — tapping the summary row toggles a per-node-index open state (collapsed by default, `<details open>` starts expanded); the body recurses through the nested renderer. Styles live in the shared `elements.css`.
- **Fix uncovered by the change**: `applyPerCallExtensions` snapshotted `marked.defaults` with a shallow spread, but marked's `use()` mutates an existing `defaults.extensions` container in place. With a built-in extension always present, per-call tokenizers leaked past `restoreDefaults` (caught by the existing "streaming per-call extensions do not leak" test). The snapshot now deep-clones the container's arrays/maps.
- Bundle size budgets bumped for the added core code (~1.3 KB raw / ~0.4 KB gzip on the main library).

Notes / limitations:

- The summary is rendered as plain text (inline markdown inside `<summary>` is not parsed; tags are stripped).
- Same-tag nesting is not supported — the body match is non-greedy to the first `</details>` (mirrors the `components` sugar limitation).
- During streaming, an unclosed `<details>` falls back to the raw html path until its closer arrives.
- `tokensToWechat()` / `tokensToAlipay()` lex with a bare `Lexer` and do not pick up the extension; `parse` / `render` / `renderNodes` do.

Covered by `src/__tests__/details.test.ts` (empty body, markdown body with blank lines and lists, `open` attribute, missing summary, other raw html untouched, user-extension override). Full suite passes (253 tests), `check:bundle` passes.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added built-in `<details>` support: `<details><summary>…</summary>…</details>` blocks (including bodies with blank-line-separated markdown) now render as collapsible sections in the bundled MiniNodeRenderer components instead of raw text. |
| 🇨🇳 Chinese | 新增内置 `<details>` 支持：`<details><summary>…</summary>…</details>` 块（含带空行的 markdown 正文）在内置 MiniNodeRenderer 组件中渲染为可折叠区块，不再显示原始标签。 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持解析并渲染可折叠的 `<details>` 内容区块。
  - 支持摘要文本、默认展开状态及点击展开/收起。
  - 微信小程序与支付宝小程序均提供一致的展示效果和样式。
  - 支持自定义扩展覆盖默认渲染逻辑。

- **改进**
  - 优化扩展配置的恢复机制，避免渲染调用之间相互影响。
  - 放宽构建产物体积检查上限。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->