### PR TITLE
docs(changelog): 1.1.0 — built-in <details> collapsible blocks

### DIFF
--- a/changelog/CHANGELOG.en-US.md
+++ b/changelog/CHANGELOG.en-US.md
@@ -8,6 +8,14 @@ User-facing API, build-output, and behavior changes are tracked here. Migration 
 
 > The site's `/changelog` timeline is generated from this file (`docs-site/scripts/build-changelog.mjs` parses the `## version` / `` `date` `` / `- **type**: …` structure). Add a new block at the top when releasing; `npm run changelog` helps assemble entries from merged PRs. Types are **Breaking** / **Added** / **Fixed** / **Improved**.
 
+## 1.1.0
+
+`2026-08-31`
+
+- **Added**: built-in `<details>` support. `<details><summary>…</summary>…</details>` previously rendered as raw text — marked's html tokenizer splits the region at blank lines into several unrelated tokens, so the opening and closing tags leaked around otherwise-rendered content. A built-in block tokenizer now captures the whole region: `<summary>` becomes a plain-text title (tags stripped), the body is lexed as regular block markdown (including blank-line-separated paragraphs and lists), and `<details open>` starts expanded. The bundled `MiniNodeRenderer` (WeChat / Alipay) renders it as a collapsible section — tapping the summary row toggles it, collapsed by default. **Behavior change:** `parse()` / `render()` now emit a new `details` token type and this markdown no longer takes the raw `html` text path; an extension registered as `name: 'details'` still overrides the built-in entirely.
+- **Fixed**: per-call extensions passed to `render(props)` / `renderNodes(props)` leaked into later calls. `applyPerCallExtensions` snapshotted `marked.defaults` with a shallow spread, but marked's `use()` mutates the existing `defaults.extensions` container and the `renderer` / `tokenizer` instances **in place**, so the snapshot aliased the very objects it was meant to restore. This previously only triggered when the instance already had `extensions` configured (container already present). All three are now cloned preserving their prototypes.
+- **Improved**: the built-in `<details>` tokenizer adds roughly 1.3 KB raw (~0.4 KB gzip) to the main library; `check-bundle` size budgets were raised to match.
+
 ## 1.0.2
 
 `2026-07-07`

--- a/changelog/CHANGELOG.zh-CN.md
+++ b/changelog/CHANGELOG.zh-CN.md
@@ -8,6 +8,14 @@ title: 更新日志
 
 > 官网 `/changelog` 时间轴由本文件生成（`docs-site/scripts/build-changelog.mjs` 解析 `## 版本`／`` `日期` ``／`- **类型**：…` 结构）。发版时在顶部新增一段即可，`npm run changelog` 可辅助从已合并 PR 拼条目。类型取 **破坏性** / **新增** / **修复** / **优化**。
 
+## 1.1.0
+
+`2026-08-31`
+
+- **新增**：内置 `<details>` 折叠块支持。此前 `<details><summary>…</summary>…</details>` 会渲染成原始文本——marked 的 html 分词器在空行处把这段切成互不相关的多个 token，开闭标签因而泄漏到已渲染内容的前后。现由内置块级分词器整块捕获：`<summary>` 取纯文本作标题（标签被剥离），正文按普通块级 markdown 解析（含空行分隔的段落与列表），`<details open>` 默认展开。内置 `MiniNodeRenderer`（微信 / 支付宝）渲染为可折叠区块，点击标题行展开收起，默认折叠。**行为变化：** `parse()` / `render()` 现在会产出新的 `details` token 类型，这段 markdown 不再走原 `html` 原始文本路径；注册 `name: 'details'` 的扩展仍可完全覆盖内置行为。
+- **修复**：`render(props)` / `renderNodes(props)` 的单次调用扩展会泄漏到后续调用。`applyPerCallExtensions` 用浅展开快照 `marked.defaults`，而 marked 的 `use()` 是**原地**改写既有的 `defaults.extensions` 容器及 `renderer` / `tokenizer` 实例，快照与被改写对象共享同一引用，还原等于没还原。此前只在实例已配置 `extensions` 时触发（容器已存在），现按原型克隆这三者。
+- **优化**：主库体积因内置 `<details>` 分词器增加约 1.3 KB（gzip 约 0.4 KB），`check-bundle` 体积预算已同步上调。
+
 ## 1.0.2
 
 `2026-07-07`

--- a/docs-site/public/site.js
+++ b/docs-site/public/site.js
@@ -893,7 +893,7 @@
   // a version label to the URL serving that version's docs. The current build
   // is always the default; entries listed here become extra dropdown options.
   var GITHUB_URL = 'https://github.com/ant-design/x-markdown-mini';
-  var CURRENT_VERSION = '1.0.2';
+  var CURRENT_VERSION = '1.1.0';
   var VERSION_MIRRORS = {
     // '1.x': 'https://1x-x-markdown-mini.example.com',
   };

--- a/docs-site/src/demos/changelog/changelog.generated.ts
+++ b/docs-site/src/demos/changelog/changelog.generated.ts
@@ -16,6 +16,58 @@ export interface GeneratedRelease {
 
 export const ZH_RELEASES: GeneratedRelease[] = [
   {
+    "version": "1.1.0",
+    "date": "2026-08-31",
+    "items": [
+      {
+        "type": "feature",
+        "html": "内置 <code>&lt;details&gt;</code> 折叠块支持。此前 <code>&lt;details&gt;&lt;summary&gt;…&lt;/summary&gt;…&lt;/details&gt;</code> 会渲染成原始文本——marked 的 html 分词器在空行处把这段切成互不相关的多个 token，开闭标签因而泄漏到已渲染内容的前后。现由内置块级分词器整块捕获：<code>&lt;summary&gt;</code> 取纯文本作标题（标签被剥离），正文按普通块级 markdown 解析（含空行分隔的段落与列表），<code>&lt;details open&gt;</code> 默认展开。内置 <code>MiniNodeRenderer</code>（微信 / 支付宝）渲染为可折叠区块，点击标题行展开收起，默认折叠。<strong>行为变化：</strong> <code>parse()</code> / <code>render()</code> 现在会产出新的 <code>details</code> token 类型，这段 markdown 不再走原 <code>html</code> 原始文本路径；注册 <code>name: 'details'</code> 的扩展仍可完全覆盖内置行为。",
+        "notes": []
+      },
+      {
+        "type": "fix",
+        "html": "<code>render(props)</code> / <code>renderNodes(props)</code> 的单次调用扩展会泄漏到后续调用。<code>applyPerCallExtensions</code> 用浅展开快照 <code>marked.defaults</code>，而 marked 的 <code>use()</code> 是<strong>原地</strong>改写既有的 <code>defaults.extensions</code> 容器及 <code>renderer</code> / <code>tokenizer</code> 实例，快照与被改写对象共享同一引用，还原等于没还原。此前只在实例已配置 <code>extensions</code> 时触发（容器已存在），现按原型克隆这三者。",
+        "notes": []
+      },
+      {
+        "type": "perf",
+        "html": "主库体积因内置 <code>&lt;details&gt;</code> 分词器增加约 1.3 KB（gzip 约 0.4 KB），<code>check-bundle</code> 体积预算已同步上调。",
+        "notes": []
+      }
+    ]
+  },
+  {
+    "version": "1.0.2",
+    "date": "2026-07-07",
+    "items": [
+      {
+        "type": "fix",
+        "html": "支付宝真机上 KaTeX 公式回退成系统字体。真机 <code>my.loadFontFace</code> 只认「已加入下载合法域名白名单的 https 网络字体」，包内本地 ttf 路径与 base64 data URI 仅在模拟器生效（此前它们能在本仓库自带 examples 里工作，是因为 examples 把字体同步到了工程根目录）。现改为从白名单 CDN 加载 KaTeX 字体（<code>mdn.alipayobjects.com</code>，20 个 ttf）。<strong>使用方需将该字体 CDN 域名加入小程序「下载合法域名」白名单。</strong> 微信仍保留可解析的本地 <code>miniprogram_npm</code> ttf（优先）+ 共享 CDN（兜底）。",
+        "notes": []
+      },
+      {
+        "type": "fix",
+        "html": "流式渲染公式时整页反复闪动。此前 <code>MiniNodeRenderer</code> 每收到一个 chunk 都会重新注册字体就绪回调，字体缓存后回调又同步触发，导致整棵渲染树反复「卸载-重挂」。现每个组件实例至多重排一次，且仅在「有公式 + 字体尚未就绪 + 非流式进行中」时触发。",
+        "notes": []
+      },
+      {
+        "type": "fix",
+        "html": "流式时有序列表序号（如 <code>1.</code>）换行。逐字入场动画把 marker 拆成多个 <code>&lt;text&gt;</code>，在仅 28rpx 宽的 marker 列里 <code>1</code> 和 <code>.</code> 分行。marker 现整体渲染为单个 <code>&lt;text&gt;</code>，与微信一致。",
+        "notes": []
+      },
+      {
+        "type": "fix",
+        "html": "尊重 <code>package.json#exports</code> 的构建工具（如 Minifish 2.0）无法解析、加载不出 <code>&lt;markdown&gt;</code> 组件。新增 <code>./es/Markdown/index</code> 与 <code>./es/MiniNodeRenderer/index</code> 无扩展名子路径导出映射（Node 的 <code>*</code> 通配不会自动补扩展名）。",
+        "notes": []
+      },
+      {
+        "type": "perf",
+        "html": "移除内联 base64 字体数据模块（<code>katex-font-data.js</code>）与支付宝包根 ttf；字体 loader 抽为每个包根仅发一份的 <code>shared/loadKatexFonts.js</code>（不再内联进每个组件 wrapper）。包体减小。",
+        "notes": []
+      }
+    ]
+  },
+  {
     "version": "1.0.1",
     "date": "2026-07-05",
     "items": [
@@ -104,6 +156,58 @@ export const ZH_RELEASES: GeneratedRelease[] = [
 ];
 
 export const EN_RELEASES: GeneratedRelease[] = [
+  {
+    "version": "1.1.0",
+    "date": "2026-08-31",
+    "items": [
+      {
+        "type": "feature",
+        "html": "built-in <code>&lt;details&gt;</code> support. <code>&lt;details&gt;&lt;summary&gt;…&lt;/summary&gt;…&lt;/details&gt;</code> previously rendered as raw text — marked's html tokenizer splits the region at blank lines into several unrelated tokens, so the opening and closing tags leaked around otherwise-rendered content. A built-in block tokenizer now captures the whole region: <code>&lt;summary&gt;</code> becomes a plain-text title (tags stripped), the body is lexed as regular block markdown (including blank-line-separated paragraphs and lists), and <code>&lt;details open&gt;</code> starts expanded. The bundled <code>MiniNodeRenderer</code> (WeChat / Alipay) renders it as a collapsible section — tapping the summary row toggles it, collapsed by default. <strong>Behavior change:</strong> <code>parse()</code> / <code>render()</code> now emit a new <code>details</code> token type and this markdown no longer takes the raw <code>html</code> text path; an extension registered as <code>name: 'details'</code> still overrides the built-in entirely.",
+        "notes": []
+      },
+      {
+        "type": "fix",
+        "html": "per-call extensions passed to <code>render(props)</code> / <code>renderNodes(props)</code> leaked into later calls. <code>applyPerCallExtensions</code> snapshotted <code>marked.defaults</code> with a shallow spread, but marked's <code>use()</code> mutates the existing <code>defaults.extensions</code> container and the <code>renderer</code> / <code>tokenizer</code> instances <strong>in place</strong>, so the snapshot aliased the very objects it was meant to restore. This previously only triggered when the instance already had <code>extensions</code> configured (container already present). All three are now cloned preserving their prototypes.",
+        "notes": []
+      },
+      {
+        "type": "perf",
+        "html": "the built-in <code>&lt;details&gt;</code> tokenizer adds roughly 1.3 KB raw (~0.4 KB gzip) to the main library; <code>check-bundle</code> size budgets were raised to match.",
+        "notes": []
+      }
+    ]
+  },
+  {
+    "version": "1.0.2",
+    "date": "2026-07-07",
+    "items": [
+      {
+        "type": "fix",
+        "html": "KaTeX formulas fell back to the system font on the Alipay real device. On device <code>my.loadFontFace</code> only accepts an https network font whose domain is on the download allowlist; package-local ttf paths and base64 data URIs work only in the simulator (they appeared to work in this repo's own examples only because the examples sync the fonts to the project root). KaTeX fonts now load from a whitelisted CDN (<code>mdn.alipayobjects.com</code>, 20 ttf). <strong>Consumers must add the font CDN domain to their mini-program download allowlist.</strong> WeChat keeps its resolvable local <code>miniprogram_npm</code> ttf (first) + shared CDN (fallback).",
+        "notes": []
+      },
+      {
+        "type": "fix",
+        "html": "whole-page flicker while streaming formulas. <code>MiniNodeRenderer</code> re-registered a font-ready callback on every chunk, and the callback fired synchronously once fonts were cached, unmounting/remounting the entire render tree each chunk. Each component instance now reflows at most once, and only when there is a formula, fonts aren't ready yet, and streaming is not in progress.",
+        "notes": []
+      },
+      {
+        "type": "fix",
+        "html": "ordered-list markers (e.g. <code>1.</code>) wrapped across lines while streaming. The per-character entrance animation split the marker into separate <code>&lt;text&gt;</code> boxes, so <code>1</code> and <code>.</code> broke onto different lines inside the 28rpx-wide marker column. Markers now render as a single <code>&lt;text&gt;</code>, matching WeChat.",
+        "notes": []
+      },
+      {
+        "type": "fix",
+        "html": "bundlers that honor <code>package.json#exports</code> (e.g. Minifish 2.0) couldn't resolve and failed to load the <code>&lt;markdown&gt;</code> component. Added <code>./es/Markdown/index</code> and <code>./es/MiniNodeRenderer/index</code> no-extension subpath export maps (Node's <code>*</code> glob does not auto-append extensions).",
+        "notes": []
+      },
+      {
+        "type": "perf",
+        "html": "removed the inlined base64 font data module (<code>katex-font-data.js</code>) and the Alipay-root ttf; the font loader is now shipped once per package root (<code>shared/loadKatexFonts.js</code>) instead of inlined into every component wrapper. Smaller package.",
+        "notes": []
+      }
+    ]
+  },
   {
     "version": "1.0.1",
     "date": "2026-07-05",

--- a/examples/alipay/package.json
+++ b/examples/alipay/package.json
@@ -3,7 +3,7 @@
     "postinstall": "node ./scripts/patch-mp-html.mjs"
   },
   "dependencies": {
-    "@ant-design/x-markdown-mini": "1.0.2",
+    "@ant-design/x-markdown-mini": "1.1.0",
     "mini-html-parser2": "^0.3.0",
     "mp-html": "^2.5.2",
     "towxml": "^3.0.6"

--- a/examples/wechat/package.json
+++ b/examples/wechat/package.json
@@ -7,7 +7,7 @@
     "postinstall": "node ./scripts/sync-npm-fixtures.mjs"
   },
   "dependencies": {
-    "@ant-design/x-markdown-mini": "1.0.2",
+    "@ant-design/x-markdown-mini": "1.1.0",
     "mini-html-parser2": "^0.3.0",
     "mp-html": "^2.5.2",
     "towxml": "^3.0.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/x-markdown-mini",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "多小程序场景下的高性能、强扩展、流式友好的 Markdown 渲染器",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [x] ❓ Other (about what?) — 发版 PR：版本号同步 + changelog

### 🔗 Related Issues

发版 PR，收口 #15 / #16（`<details>` 折叠块支持）。

### 💡 Background and Solution

1.0.2 以来 main 上唯一的用户可见变更是 #16 的内置 `<details>` 支持。本 PR 只做发版收口，不含代码改动：

- **版本号同步 4 处**（少一处就会挂 `npm test`）：`package.json`、`docs-site/public/site.js` 的 `CURRENT_VERSION`、`examples/alipay/package.json`、`examples/wechat/package.json`。
- **changelog 双语各新增一段 1.1.0**（`changelog/CHANGELOG.{zh-CN,en-US}.md`），并重跑 `docs-site/scripts/build-changelog.mjs` 更新站点时间轴的 `changelog.generated.ts`。

**为什么是 minor 而不是 patch：** `<details>` 是一项新增能力，且 `parse()` / `render()` 现在会产出新的 `details` token 类型——这段 markdown 此前走的是原始 `html` 文本路径。下游若对 token 流做穷举分支，需要知道这一点，patch 号会掩盖它。

`package-lock.json` 的根 `version` 字段保持不动（它从 1.0.0 起就没跟着 bump 过，且发布走 publish-from-dist，由 `prepare-publish.mjs` 依据 `package.json` 生成 `dist/package.json`，不读 lock）。

本地验证（Node 22）：

- `npm run build` — exit 0，`prepared dist/ as publish root (v1.1.0)`
- `npx vitest run` — **255 passed / 28 files**（含两处版本同步断言）
- `npm run check:bundle` — 全部通过
- `npm run check:examples` — `examples config ok`

合并后 `deploy-docs.yml` 会重新发布站点；npm 发布是另一条独立触发，本地 `npm run release` 手动执行。

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Release 1.1.0. Added built-in `<details>` support: `<details><summary>…</summary>…</details>` blocks (including bodies with blank-line-separated markdown) now render as collapsible sections in the bundled MiniNodeRenderer components instead of raw text. Fixed per-call extensions leaking into later `render`/`renderNodes` calls. |
| 🇨🇳 Chinese | 发布 1.1.0。新增内置 `<details>` 支持：`<details><summary>…</summary>…</details>` 块（含带空行的 markdown 正文）在内置 MiniNodeRenderer 组件中渲染为可折叠区块，不再显示原始标签。修复单次调用扩展泄漏到后续 `render`/`renderNodes` 调用。 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持 `<details>` 折叠内容的解析与渲染，并可通过扩展进行覆盖。
* **问题修复**
  * 修复单次渲染调用的扩展配置影响后续调用的问题，确保配置彼此隔离。
* **文档**
  * 新增 1.1.0 更新日志，记录功能、修复及体积预算调整。
* **版本更新**
  * 版本升级至 1.1.0，示例项目与文档站点同步更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->